### PR TITLE
Fix/conversation detail issue

### DIFF
--- a/frontend/src/components/features/trajectory/trajectory-actions.tsx
+++ b/frontend/src/components/features/trajectory/trajectory-actions.tsx
@@ -25,12 +25,14 @@ export function TrajectoryActions({
         onClick={onPositiveFeedback}
         icon={<ThumbsUpIcon width={15} height={15} />}
         tooltip={t(I18nKey.BUTTON$MARK_HELPFUL)}
+        disabled={true}
       />
       <TrajectoryActionButton
         testId="negative-feedback"
         onClick={onNegativeFeedback}
         icon={<ThumbDownIcon width={15} height={15} />}
         tooltip={t(I18nKey.BUTTON$MARK_NOT_HELPFUL)}
+        disabled={true}
       />
       <TrajectoryActionButton
         testId="export-trajectory"

--- a/frontend/src/components/shared/buttons/trajectory-action-button.tsx
+++ b/frontend/src/components/shared/buttons/trajectory-action-button.tsx
@@ -5,6 +5,7 @@ interface TrajectoryActionButtonProps {
   onClick: () => void;
   icon: React.ReactNode;
   tooltip?: string;
+  disabled?: boolean;
 }
 
 export function TrajectoryActionButton({
@@ -12,13 +13,15 @@ export function TrajectoryActionButton({
   onClick,
   icon,
   tooltip,
+  disabled,
 }: TrajectoryActionButtonProps) {
   const button = (
     <button
       type="button"
       data-testid={testId}
       onClick={onClick}
-      className="button-base p-1 hover:bg-neutral-500"
+      className={`button-base p-1 hover:bg-neutral-500 ${disabled && "cursor-not-allowed"}`}
+      disabled={disabled}
     >
       {icon}
     </button>

--- a/frontend/src/context/ws-client-provider.tsx
+++ b/frontend/src/context/ws-client-provider.tsx
@@ -28,6 +28,7 @@ import {
 } from "#/types/core/guards";
 import { useOptimisticUserMessage } from "#/hooks/use-optimistic-user-message";
 import { useWSErrorMessage } from "#/hooks/use-ws-error-message";
+import { isAuthenticated } from "#/utils/isAuth";
 
 export type WebSocketStatus = "CONNECTING" | "CONNECTED" | "DISCONNECTED";
 
@@ -309,12 +310,15 @@ export function WsClientProvider({
     // Set initial status...
     setWebSocketStatus("CONNECTING");
 
+    const { token } = isAuthenticated();
+
     const lastEvent = lastEventRef.current;
     const query = {
       latest_event_id: lastEvent?.id ?? -1,
       conversation_id: conversationId,
       providers_set: providers,
       session_api_key: conversation.session_api_key, // Have to set here because socketio doesn't support custom headers. :(
+      access_token: token,
     };
 
     let baseUrl = null;

--- a/openhands/server/listen_socket.py
+++ b/openhands/server/listen_socket.py
@@ -66,11 +66,16 @@ async def connect(connection_id: str, environ: dict) -> None:
         cookies_str = environ.get('HTTP_COOKIE', '')
         # Get Authorization header from the environment
         # Headers in WSGI/ASGI are prefixed with 'HTTP_' and have dashes replaced with underscores
-        authorization_header = environ.get('HTTP_AUTHORIZATION', None)
+        # authorization_header = environ.get('HTTP_AUTHORIZATION', None)
+        access_token = query_params.get('access_token', [None])[0]
+
         conversation_validator = create_conversation_validator()
         user_id = await conversation_validator.validate(
-            conversation_id, cookies_str, authorization_header
+            conversation_id,
+            cookies_str,
+            access_token,
         )
+
         logger.info(
             f'User {user_id} is allowed to connect to conversation {conversation_id}'
         )

--- a/openhands/storage/conversation/conversation_validator.py
+++ b/openhands/storage/conversation/conversation_validator.py
@@ -1,6 +1,10 @@
 import os
 
+from fastapi import Depends
+from pydantic import SecretStr
+from openhands.server.user_auth.h2loop_user_auth import H2LoopUserAuth
 from openhands.utils.import_utils import get_impl
+from openhands.server.user_auth import get_user_id
 
 
 class ConversationValidator:
@@ -23,7 +27,9 @@ class ConversationValidator:
         cookies_str: str,
         authorization_header: str | None = None,
     ) -> str | None:
-        return None
+        user_auth = H2LoopUserAuth(_access_token=SecretStr(authorization_header))
+        user_id = await user_auth.get_user_id()
+        return user_id
 
 
 def create_conversation_validator() -> ConversationValidator:


### PR DESCRIPTION
- Conversation details not loaded
- Settings not found

The issue was due to user_id being None on websocket connection. So, passed the token from the frontend websocket initialization to pass the token and get the user id.

- Disabled like, dislike conversation buttons