### PR TITLE
Attached file chunk message llm | Highlight attached file on message box

### DIFF
--- a/frontend/src/api/attached-file-service.api.ts
+++ b/frontend/src/api/attached-file-service.api.ts
@@ -1,0 +1,25 @@
+import { openHands } from "./open-hands-axios";
+
+export interface Chunk {
+  text: string;
+  file_name: string;
+}
+
+export interface ChunksResponse {
+  chunks: Chunk[];
+}
+
+export class AttachedFileService {
+  static async getChunksFromFiles(fileIds: string[]): Promise<ChunksResponse> {
+    const { data } = await openHands.get<ChunksResponse>(
+      "https://mocki.io/v1/4277924c-8af4-4d8b-8283-883ea7b15d5e",
+      {
+        params: {
+          file_ids: fileIds,
+        },
+      },
+    );
+
+    return data;
+  }
+}

--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { useTranslation } from "react-i18next";
 import { I18nKey } from "#/i18n/declaration";
@@ -110,25 +110,12 @@ export function ChatInput({
 
   const handleSubmitMessage = () => {
     const message = value || textareaRef.current?.value || "";
-    if (message.trim() || selectedFiles.length > 0) {
-      // Include file references in the message
-      let finalMessage = message;
-      if (selectedFiles.length > 0) {
-        const fileRefs = selectedFiles
-          .map((f) => `@${f.name}:${f.id}`)
-          .join(" ");
-        finalMessage =
-          selectedFiles.length > 0 && !message.trim()
-            ? fileRefs
-            : `${fileRefs} ${message}`.trim();
-      }
 
-      onSubmit(finalMessage, selectedFiles);
-      onChange?.("");
-      setSelectedFiles([]);
-      if (textareaRef.current) {
-        textareaRef.current.value = "";
-      }
+    onSubmit(message, selectedFiles);
+    onChange?.("");
+    setSelectedFiles([]);
+    if (textareaRef.current) {
+      textareaRef.current.value = "";
     }
   };
 

--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -23,7 +23,7 @@ interface DataSource {
   [key: string]: any;
 }
 
-interface SelectedFile {
+export interface AttachedFile {
   id: string;
   name: string;
   source: DataSource;
@@ -36,7 +36,7 @@ interface ChatInputProps {
   showButton?: boolean;
   value?: string;
   maxRows?: number;
-  onSubmit: (message: string) => void;
+  onSubmit: (message: string, attachedFiles: AttachedFile[]) => void;
   onStop?: () => void;
   onChange?: (message: string) => void;
   onFocus?: () => void;
@@ -74,7 +74,7 @@ export function ChatInput({
   >([]);
   const [searchFileText, setSearchFileText] = React.useState("");
   const [isLoadingDataSources, setIsLoadingDataSources] = React.useState(false);
-  const [selectedFiles, setSelectedFiles] = React.useState<SelectedFile[]>([]);
+  const [selectedFiles, setSelectedFiles] = React.useState<AttachedFile[]>([]);
   const containerRef = React.useRef<HTMLDivElement>(null);
 
   const handlePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -123,7 +123,7 @@ export function ChatInput({
             : `${fileRefs} ${message}`.trim();
       }
 
-      onSubmit(finalMessage);
+      onSubmit(finalMessage, selectedFiles);
       onChange?.("");
       setSelectedFiles([]);
       if (textareaRef.current) {
@@ -227,7 +227,7 @@ export function ChatInput({
     }
 
     // Add to selected files
-    const newFile: SelectedFile = {
+    const newFile: AttachedFile = {
       id: fileId,
       name: fileName,
       source: file,

--- a/frontend/src/components/features/chat/chat-input.tsx
+++ b/frontend/src/components/features/chat/chat-input.tsx
@@ -114,7 +114,9 @@ export function ChatInput({
       // Include file references in the message
       let finalMessage = message;
       if (selectedFiles.length > 0) {
-        const fileRefs = selectedFiles.map((f) => `@${f.name}`).join(" ");
+        const fileRefs = selectedFiles
+          .map((f) => `@${f.name}:${f.id}`)
+          .join(" ");
         finalMessage =
           selectedFiles.length > 0 && !message.trim()
             ? fileRefs

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -37,6 +37,9 @@ import { ChatSimulator } from "./chat-simulator";
 import { GENERATE_CLASS_DIAGRAM_MESSAGES } from "#/fake_scripts/generate_class_diagram_data";
 import { useSimulationMode } from "#/fake_scripts/simulation_context";
 import { AttachedFile } from "./chat-input";
+import { useGetAttachedFilesChunks } from "#/hooks/query/use-get-attached-files-chunks";
+import _ from "lodash";
+import { AttachedFileService } from "#/api/attached-file-service.api";
 
 function getEntryPoint(
   hasRepository: boolean | null,
@@ -130,9 +133,31 @@ export function ChatInterface() {
 
     skippedFiles.forEach((f) => displayErrorToast(f.reason));
 
+    let groupedStrings: { fileName: string; text: string }[] = [];
+    if (attachedFiles.length > 0) {
+      const chunkResponse = await AttachedFileService.getChunksFromFiles(
+        attachedFiles.map((file) => file.id),
+      );
+
+      if (chunkResponse?.chunks?.length) {
+        const grouped = _.groupBy(chunkResponse?.chunks, "file_name");
+
+        groupedStrings = _.map(grouped, (chunks, fileName) => ({
+          fileName,
+          text: chunks.map((c) => c.text).join(" "),
+        }));
+      }
+    }
+
     const filePrompt = `${t("CHAT_INTERFACE$AUGMENTED_PROMPT_FILES_TITLE")}: ${uploadedFiles.join("\n\n")}`;
-    const prompt =
+    let prompt =
       uploadedFiles.length > 0 ? `${content}\n\n${filePrompt}` : content;
+    if (groupedStrings.length > 0) {
+      prompt += "\n\nHere are the relevant chunks from the workspace files: ";
+      groupedStrings.forEach((group) => {
+        prompt += `\n\nFile Name: ${group.fileName} and it's chunks: ${group.text}`;
+      });
+    }
 
     send(
       createChatMessage(

--- a/frontend/src/components/features/chat/chat-interface.tsx
+++ b/frontend/src/components/features/chat/chat-interface.tsx
@@ -36,6 +36,7 @@ import { getIndicatorColor, getStatusCode } from "#/utils/status";
 import { ChatSimulator } from "./chat-simulator";
 import { GENERATE_CLASS_DIAGRAM_MESSAGES } from "#/fake_scripts/generate_class_diagram_data";
 import { useSimulationMode } from "#/fake_scripts/simulation_context";
+import { AttachedFile } from "./chat-input";
 
 function getEntryPoint(
   hasRepository: boolean | null,
@@ -100,6 +101,7 @@ export function ChatInterface() {
     content: string,
     images: File[],
     files: File[],
+    attachedFiles: AttachedFile[],
   ) => {
     if (events.length === 0) {
       posthog.capture("initial_query_submitted", {
@@ -132,7 +134,15 @@ export function ChatInterface() {
     const prompt =
       uploadedFiles.length > 0 ? `${content}\n\n${filePrompt}` : content;
 
-    send(createChatMessage(prompt, imageUrls, uploadedFiles, timestamp));
+    send(
+      createChatMessage(
+        prompt,
+        imageUrls,
+        uploadedFiles,
+        attachedFiles,
+        timestamp,
+      ),
+    );
     setOptimisticUserMessage(content);
     setMessageToSend(null);
   };
@@ -239,7 +249,9 @@ export function ChatInterface() {
             events.length > 0 &&
             !optimisticUserMessage && (
               <ActionSuggestions
-                onSuggestionsClick={(value) => handleSendMessage(value, [], [])}
+                onSuggestionsClick={(value) =>
+                  handleSendMessage(value, [], [], [])
+                }
               />
             )}
         </div>

--- a/frontend/src/components/features/chat/event-content-helpers/parse-message-from-event.ts
+++ b/frontend/src/components/features/chat/event-content-helpers/parse-message-from-event.ts
@@ -9,10 +9,17 @@ export const parseMessageFromEvent = (
   event: UserMessageAction | AssistantMessageAction,
 ): string => {
   const m = isUserMessage(event) ? event.args.content : event.message;
-  if (!event.args.file_urls || event.args.file_urls.length === 0) {
+  const uploadedFilesNotPresent =
+    !event.args.file_urls || event.args.file_urls.length === 0;
+  const attachedFilesNotPresent =
+    !event.args.attached_files || event.args.attached_files.length === 0;
+
+  if (uploadedFilesNotPresent && attachedFilesNotPresent) {
     return m;
   }
-  const delimiter = i18n.t("CHAT_INTERFACE$AUGMENTED_PROMPT_FILES_TITLE");
+  const delimiter = !uploadedFilesNotPresent
+    ? i18n.t("CHAT_INTERFACE$AUGMENTED_PROMPT_FILES_TITLE")
+    : "Here are the relevant chunks from the workspace files:";
   const parts = m.split(delimiter);
 
   return parts[0];

--- a/frontend/src/components/features/chat/event-message.tsx
+++ b/frontend/src/components/features/chat/event-message.tsx
@@ -25,6 +25,7 @@ import { LikertScale } from "../feedback/likert-scale";
 
 import { useConfig } from "#/hooks/query/use-config";
 import { useFeedbackExists } from "#/hooks/query/use-feedback-exists";
+import { CiAt } from "react-icons/ci";
 
 const hasThoughtProperty = (
   obj: Record<string, unknown>,
@@ -103,6 +104,16 @@ export function EventMessage({
         {event.args.file_urls && event.args.file_urls.length > 0 && (
           <FileList files={event.args.file_urls} />
         )}
+        {event.args.attached_files &&
+          event.args.attached_files.length > 0 &&
+          event.args.attached_files.map((file) => (
+            <div key={file.id} className="flex items-center gap-1">
+              <CiAt className="h-4 w-4" />{" "}
+              <span className="bg-blue-600/20 border border-blue-500/30 text-blue-200 rounded-full px-2 py-1">
+                {file.name}
+              </span>
+            </div>
+          ))}
         {shouldShowConfirmationButtons && <ConfirmationButtons />}
       </ChatMessage>
     );

--- a/frontend/src/components/features/chat/interactive-chat-box.tsx
+++ b/frontend/src/components/features/chat/interactive-chat-box.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ChatInput } from "./chat-input";
+import { AttachedFile, ChatInput } from "./chat-input";
 import { cn } from "#/utils/utils";
 import { ImageCarousel } from "../images/image-carousel";
 import { UploadImageInput } from "../images/upload-image-input";
@@ -9,7 +9,12 @@ import { isFileImage } from "#/utils/is-file-image";
 interface InteractiveChatBoxProps {
   isDisabled?: boolean;
   mode?: "stop" | "submit";
-  onSubmit: (message: string, images: File[], files: File[]) => void;
+  onSubmit: (
+    message: string,
+    images: File[],
+    files: File[],
+    attachedFiles: AttachedFile[],
+  ) => void;
   onStop: () => void;
   value?: string;
   onChange?: (message: string) => void;
@@ -50,8 +55,8 @@ export function InteractiveChatBox({
     setImages(removeElementByIndex(images, index));
   };
 
-  const handleSubmit = (message: string) => {
-    onSubmit(message, images, files);
+  const handleSubmit = (message: string, attachedFiles: AttachedFile[]) => {
+    onSubmit(message, images, files, attachedFiles);
     setFiles([]);
     setImages([]);
     if (message) {

--- a/frontend/src/hooks/query/use-get-attached-files-chunks.ts
+++ b/frontend/src/hooks/query/use-get-attached-files-chunks.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { AttachedFileService } from "#/api/attached-file-service.api";
+
+export const useGetAttachedFilesChunks = (fileIds: string[]) => {
+  return useQuery({
+    queryKey: ["get-attached-files-chunks", fileIds],
+    queryFn: () => AttachedFileService.getChunksFromFiles(fileIds),
+    enabled: fileIds.length > 0,
+  });
+};

--- a/frontend/src/services/chat-service.ts
+++ b/frontend/src/services/chat-service.ts
@@ -1,14 +1,22 @@
+import { AttachedFile } from "#/components/features/chat/chat-input";
 import ActionType from "#/types/action-type";
 
 export function createChatMessage(
   message: string,
   image_urls: string[],
   file_urls: string[],
+  attached_files: AttachedFile[],
   timestamp: string,
 ) {
   const event = {
     action: ActionType.MESSAGE,
-    args: { content: message, image_urls, file_urls, timestamp },
+    args: {
+      content: message,
+      image_urls,
+      file_urls,
+      attached_files,
+      timestamp,
+    },
   };
   return event;
 }

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -1,5 +1,6 @@
 import { OpenHandsActionEvent } from "./base";
 import { ActionSecurityRisk } from "#/state/security-analyzer-slice";
+import { AttachedFile } from "#/components/features/chat/chat-input";
 
 export interface UserMessageAction extends OpenHandsActionEvent<"message"> {
   source: "user";
@@ -7,6 +8,7 @@ export interface UserMessageAction extends OpenHandsActionEvent<"message"> {
     content: string;
     image_urls: string[];
     file_urls: string[];
+    attached_files: AttachedFile[];
   };
 }
 
@@ -38,6 +40,7 @@ export interface AssistantMessageAction
     thought: string;
     image_urls: string[] | null;
     file_urls: string[];
+    attached_files: AttachedFile[];
     wait_for_response: boolean;
   };
 }

--- a/openhands/events/action/message.py
+++ b/openhands/events/action/message.py
@@ -11,6 +11,7 @@ class MessageAction(Action):
     content: str
     file_urls: list[str] | None = None
     image_urls: list[str] | None = None
+    attached_files: list[str] | None = None
     wait_for_response: bool = False
     action: str = ActionType.MESSAGE
     security_risk: ActionSecurityRisk | None = None
@@ -37,6 +38,9 @@ class MessageAction(Action):
         if self.file_urls:
             for url in self.file_urls:
                 ret += f'\nFILE_URL: {url}'
+        if self.attached_files:
+            for file in self.attached_files:
+                ret += f'\ATTACHED FILE NAME: {file}'
         return ret
 
 

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -251,26 +251,37 @@ class LLM(RetryMixin, DebugMixin):
                 # Check if content is a string (not a list of content items)
                 if isinstance(content, str):
                     # Check if the message contains file references from selectedFiles
-                    # File references will be at the beginning of the message in the format "@filename"
+                    # File references will be at the beginning of the message in the format "@filename:fileID"
                     words = content.split()
                     file_references = []
+                    file_ids = []
 
-                    # Only collect file references from the beginning of the message
-                    # TODO: HANDLE: there can be @any_random_text from the user -> which may not be attached files
+                    # Only collect valid file references from the beginning of the message
+                    # This handles the case where users might type @anything that isn't a file reference
                     for word in words:
-                        if word.startswith('@'):
-                            file_references.append(word[1:])  # Remove the @ symbol
+                        if word.startswith('@') and ':' in word:
+                            # Extract filename and fileID
+                            parts = word[1:].split(':', 1)  # Remove @ and split by first :
+                            if len(parts) == 2:
+                                filename, file_id = parts
+                                file_references.append(filename)
+                                file_ids.append(file_id)
                         else:
+                            # Once we hit a non-file reference or invalid format, stop collecting
                             break
 
-                    if file_references:
-                        logger.debug(
-                            f'Found file references at beginning of message: {file_references}'
+                    if file_references and file_ids:
+                        logger.info(
+                            f'Found valid file references at beginning of message: {file_references} with IDs: {file_ids}'
                         )
 
                         try:
+                            # Fetch chunks from the API with file IDs as parameters
+                            params = {'file_ids': ','.join(file_ids)}
+                            print(params)
                             response = httpx.get(
                                 'https://mocki.io/v1/dec6cdb4-d068-452c-b88b-0ac29d0c788e',
+                                params=params,
                                 timeout=10,
                             )
                             if response.status_code == 200:

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -210,6 +210,9 @@ class LLM(RetryMixin, DebugMixin):
         )
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             """Wrapper for the litellm completion function. Logs the input and output of the completion function."""
+
+            import httpx
+
             from openhands.io import json
 
             messages_kwarg: list[dict[str, Any]] | dict[str, Any] = []
@@ -234,6 +237,61 @@ class LLM(RetryMixin, DebugMixin):
             messages: list[dict[str, Any]] = (
                 messages_kwarg if isinstance(messages_kwarg, list) else [messages_kwarg]
             )
+
+            # Only check the most recent user message for file references
+            # Find the last user message in the list
+            user_messages = [
+                i for i, msg in enumerate(messages) if msg.get('role') == 'user'
+            ]
+            if user_messages:
+                last_user_msg_index = user_messages[-1]
+                message = messages[last_user_msg_index]
+                content = message.get('content', '')
+
+                # Check if content is a string (not a list of content items)
+                if isinstance(content, str):
+                    # Check if the message contains file references from selectedFiles
+                    # File references will be at the beginning of the message in the format "@filename"
+                    words = content.split()
+                    file_references = []
+
+                    # Only collect file references from the beginning of the message
+                    # TODO: HANDLE: there can be @any_random_text from the user -> which may not be attached files
+                    for word in words:
+                        if word.startswith('@'):
+                            file_references.append(word[1:])  # Remove the @ symbol
+                        else:
+                            break
+
+                    if file_references:
+                        logger.debug(
+                            f'Found file references at beginning of message: {file_references}'
+                        )
+
+                        try:
+                            response = httpx.get(
+                                'https://mocki.io/v1/dec6cdb4-d068-452c-b88b-0ac29d0c788e',
+                                timeout=10,
+                            )
+                            if response.status_code == 200:
+                                chunks_data = response.json()
+                                chunks = chunks_data.get('chunks', [])
+
+                                chunks_text = ''
+                                for chunk in chunks:
+                                    chunks_text += f'{chunk.get("text", "")} '
+
+                                if chunks_text:
+                                    messages[last_user_msg_index]['content'] = (
+                                        f'{content}\n\nFile Content:\n{chunks_text.strip()}'
+                                    )
+                                    logger.debug('Added file chunks to message')
+                            else:
+                                logger.error(
+                                    f'Failed to fetch chunks: {response.status_code}'
+                                )
+                        except Exception as e:
+                            logger.error(f'Error fetching chunks: {e}')
 
             # handle conversion of to non-function calling messages if needed
             original_fncall_messages = copy.deepcopy(messages)
@@ -302,6 +360,8 @@ class LLM(RetryMixin, DebugMixin):
                     message=r'.*content=.*upload.*',
                     category=DeprecationWarning,
                 )
+                # Update kwargs with modified messages
+                kwargs['messages'] = messages
                 resp: ModelResponse = self._completion_unwrapped(*args, **kwargs)
 
             # Calculate and record latency

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -235,8 +235,6 @@ class LLM(RetryMixin, DebugMixin):
                 messages_kwarg if isinstance(messages_kwarg, list) else [messages_kwarg]
             )
 
-            logger.info(f"MESSAGE TO LLM: {messages}")
-
             # handle conversion of to non-function calling messages if needed
             original_fncall_messages = copy.deepcopy(messages)
             mock_fncall_tools = None

--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -210,9 +210,6 @@ class LLM(RetryMixin, DebugMixin):
         )
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             """Wrapper for the litellm completion function. Logs the input and output of the completion function."""
-
-            import httpx
-
             from openhands.io import json
 
             messages_kwarg: list[dict[str, Any]] | dict[str, Any] = []
@@ -238,71 +235,7 @@ class LLM(RetryMixin, DebugMixin):
                 messages_kwarg if isinstance(messages_kwarg, list) else [messages_kwarg]
             )
 
-            # Only check the most recent user message for file references
-            # Find the last user message in the list
-            user_messages = [
-                i for i, msg in enumerate(messages) if msg.get('role') == 'user'
-            ]
-            if user_messages:
-                last_user_msg_index = user_messages[-1]
-                message = messages[last_user_msg_index]
-                content = message.get('content', '')
-
-                # Check if content is a string (not a list of content items)
-                if isinstance(content, str):
-                    # Check if the message contains file references from selectedFiles
-                    # File references will be at the beginning of the message in the format "@filename:fileID"
-                    words = content.split()
-                    file_references = []
-                    file_ids = []
-
-                    # Only collect valid file references from the beginning of the message
-                    # This handles the case where users might type @anything that isn't a file reference
-                    for word in words:
-                        if word.startswith('@') and ':' in word:
-                            # Extract filename and fileID
-                            parts = word[1:].split(':', 1)  # Remove @ and split by first :
-                            if len(parts) == 2:
-                                filename, file_id = parts
-                                file_references.append(filename)
-                                file_ids.append(file_id)
-                        else:
-                            # Once we hit a non-file reference or invalid format, stop collecting
-                            break
-
-                    if file_references and file_ids:
-                        logger.info(
-                            f'Found valid file references at beginning of message: {file_references} with IDs: {file_ids}'
-                        )
-
-                        try:
-                            # Fetch chunks from the API with file IDs as parameters
-                            params = {'file_ids': ','.join(file_ids)}
-                            print(params)
-                            response = httpx.get(
-                                'https://mocki.io/v1/dec6cdb4-d068-452c-b88b-0ac29d0c788e',
-                                params=params,
-                                timeout=10,
-                            )
-                            if response.status_code == 200:
-                                chunks_data = response.json()
-                                chunks = chunks_data.get('chunks', [])
-
-                                chunks_text = ''
-                                for chunk in chunks:
-                                    chunks_text += f'{chunk.get("text", "")} '
-
-                                if chunks_text:
-                                    messages[last_user_msg_index]['content'] = (
-                                        f'{content}\n\nFile Content:\n{chunks_text.strip()}'
-                                    )
-                                    logger.debug('Added file chunks to message')
-                            else:
-                                logger.error(
-                                    f'Failed to fetch chunks: {response.status_code}'
-                                )
-                        except Exception as e:
-                            logger.error(f'Error fetching chunks: {e}')
+            logger.info(f"MESSAGE TO LLM: {messages}")
 
             # handle conversion of to non-function calling messages if needed
             original_fncall_messages = copy.deepcopy(messages)

--- a/openhands/utils/conversation_summary.py
+++ b/openhands/utils/conversation_summary.py
@@ -41,7 +41,7 @@ async def generate_conversation_title(
         messages = [
             {
                 'role': 'system',
-                'content': 'You are a helpful assistant that generates concise, descriptive titles for conversations with OpenHands. OpenHands is a helpful AI agent that can interact with a computer to solve tasks using bash terminal, file editor, and browser. Given a user message (which may be truncated), generate a concise, descriptive title for the conversation. Return only the title, with no additional text, quotes, or explanations.',
+                'content': 'You are a helpful assistant that generates concise, descriptive titles for conversations with OpenHands. H2Loop is a helpful AI agent that can interact with a computer to solve tasks using bash terminal, file editor, and browser. Given a user message (which may be truncated), generate a concise, descriptive title for the conversation. Return only the title, with no additional text, quotes, or explanations.',
             },
             {
                 'role': 'user',


### PR DESCRIPTION
- Call the API in between with the attached file ID which returns the chunks (dummy for now):
```{“chunks”: [ {“text”: “abc…”, “file_name”: “abc.pdf”}, ... ]}```
    Attach those chunks along with the user message and send it to LLM.

- Highlight @selected_file on message box UI