### PR TITLE
fix: remove unused security risk parameters from str_replace_editor tool

### DIFF
--- a/openhands/agenthub/codeact_agent/tools/str_replace_editor.py
+++ b/openhands/agenthub/codeact_agent/tools/str_replace_editor.py
@@ -1,9 +1,5 @@
 from litellm import ChatCompletionToolParam, ChatCompletionToolParamFunctionChunk
 
-from openhands.agenthub.codeact_agent.tools.security_utils import (
-    RISK_LEVELS,
-    SECURITY_RISK_DESC,
-)
 from openhands.llm.tool_names import STR_REPLACE_EDITOR_TOOL_NAME
 
 _DETAILED_STR_REPLACE_EDITOR_DESCRIPTION = """Custom editing tool for viewing, creating and editing files in plain-text format
@@ -104,13 +100,8 @@ def create_str_replace_editor_tool(
                         'items': {'type': 'integer'},
                         'type': 'array',
                     },
-                    'security_risk': {
-                        'type': 'string',
-                        'description': SECURITY_RISK_DESC,
-                        'enum': RISK_LEVELS,
-                    },
                 },
-                'required': ['command', 'path', 'security_risk'],
+                'required': ['command', 'path'],
             },
         ),
     )

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -44,7 +44,7 @@ from openhands.events.action import (
     CmdRunAction,
     FileEditAction,
     FileReadAction,
-    FileWriteAction
+    FileWriteAction,
 )
 from openhands.events.event import FileEditSource, FileReadSource
 from openhands.events.observation import (
@@ -54,7 +54,7 @@ from openhands.events.observation import (
     FileEditObservation,
     FileReadObservation,
     FileWriteObservation,
-    Observation
+    Observation,
 )
 from openhands.events.serialization import event_from_dict, event_to_dict
 from openhands.runtime.browser import browse


### PR DESCRIPTION
Fix for missing required parameters for function 'str_replace_editor': {'security_risk'}